### PR TITLE
Add "_csrf_token" accepted CSRF token names list

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/anticsrf/AntiCsrfParam.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/anticsrf/AntiCsrfParam.java
@@ -60,7 +60,8 @@ public class AntiCsrfParam extends AbstractParam {
         "_csrfSecret",
         "__csrf_magic",
         "CSRF",
-        "_token"
+        "_token",
+        "_csrf_token"
     };
 
     private List<AntiCsrfParamToken> tokens = null;


### PR DESCRIPTION
Add "_csrf_token" to the list of acceptable CSRF token names when scanning for "Absence of Anti-CSRF Tokens".